### PR TITLE
rename: renomear arquivo editProfile para EditProfile

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -7,7 +7,7 @@ import Login from "./src/telas/Login";
 import Signup from "./src/telas/Signup";
 import Home from "./src/telas/Home/Home";
 import Habitos from "./src/telas/Habitos";
-import EditProfileScreen from "./src/telas/EditProfile/editProfile";
+import EditProfileScreen from "./src/telas/EditProfile/EditProfile";
 
 const Stack = createNativeStackNavigator();
 

--- a/frontend/src/telas/EditProfile/EditProfile.js
+++ b/frontend/src/telas/EditProfile/EditProfile.js
@@ -10,7 +10,7 @@ import {
   Alert,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import { styles } from "../EditProfile/styles";
+import { styles } from "./styles";
 import Cabecalho from "../../components/Cabecalho";
 
 export default function EditProfileScreen({ navigation }) {


### PR DESCRIPTION
Renomeado o arquivo de editProfile.js para EditProfile.js para manter padronização
de nomenclatura dos componentes e evitar problemas de importação.